### PR TITLE
Make opencv-python an opt-in dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,10 +28,9 @@ requirements = [
     "scipy>=1.2.1",
     "numpy",
     "joblib",
-    "opencv-python",
     "scikit-learn",
 ]
-extras_require = {"dev": ["pytest", "tox"]}
+extras_require = {"dev": ["pytest", "tox"], "with-opencv": ["opencv-python"]}
 
 cmake_args = []
 if platform.system() == "Windows":


### PR DESCRIPTION
A lot of our users have an OpenCV installation already and might not want to install `opencv-python` ontop. This change removes this module from the dependency and adds an install option if one wants it. Use `pip install pye3d[with-opencv]` to install `pye3d` with `opencv-python`