### PR TITLE
Proper background process

### DIFF
--- a/pye3d/background_helper.py
+++ b/pye3d/background_helper.py
@@ -11,121 +11,157 @@ See COPYING and COPYING.LESSER for license details.
 
 import logging
 import multiprocessing as mp
+import multiprocessing.connection
 import signal
 from ctypes import c_bool
+from typing import Callable, Any, Dict, Tuple
 
 logger = logging.getLogger(__name__)
 
 
-class EarlyCancellationError(Exception):
-    pass
+class BackgroundProcess:
+    class StoppedError(Exception):
+        """Interaction with a BackgroundProcess that was stopped."""
 
+    class NothingToReceiveError(Exception):
+        """Trying to receive data from BackgroundProcess without sending input first."""
 
-class Task_Proxy:
-    """Future like object that runs a given generator in the background and returns is able to return the results incrementally"""
+    class MultipleSendError(Exception):
+        """Trying to send data without first receiving previous output."""
 
-    def __init__(self, name, generator, args=(), kwargs={}, context=...):
-        super().__init__()
-        if context is ...:
-            context = mp.get_context()
+    def __init__(self, function: Callable):
+        self._running = True
+        self._busy = False
 
-        self._should_terminate_flag = context.Value(c_bool, 0)
-        self._completed = False
-        self._canceled = False
+        self._pipe, remote_pipe = mp.Pipe(duplex=True)
+        self._should_terminate_flag = mp.Value(c_bool, 0)
 
-        pipe_recv, pipe_send = context.Pipe(False)
-        wrapper_args = self._prepare_wrapper_args(
-            pipe_send, self._should_terminate_flag, generator
+        self._process = mp.Process(
+            name="Pye3D Background Process",
+            daemon=True,
+            target=BackgroundProcess._worker,
+            kwargs=dict(
+                function=function,
+                pipe=remote_pipe,
+                should_terminate_flag=self._should_terminate_flag,
+            ),
         )
-        wrapper_args.extend(args)
-        self.process = context.Process(
-            target=self._wrapper, name=name, args=wrapper_args, kwargs=kwargs
-        )
-        self.process.daemon = True
-        self.process.start()
-        self.pipe = pipe_recv
+        self._process.start()
 
-    def _wrapper(self, pipe, _should_terminate_flag, generator, *args, **kwargs):
-        """Executed in background, pipes generator results to foreground
+    @property
+    def running(self) -> bool:
+        """Whether background task is running (not necessarily doing work)."""
+        return self._running
 
-        All exceptions are caught, forwarded to the foreground, and raised in
-        `Task_Proxy.fetch()`. This allows users to handle failure gracefully
-        as well as raising their own exceptions in the background task.
+    @property
+    def busy(self) -> bool:
+        """Whether background task is doing work or ready to collect results."""
+        return self._busy
+
+    def send(self, *args: Tuple[Any], **kwargs: Dict[Any, Any]):
+        """Send data to background process for processing.
+
+        Raises MultipleSendError when called again without a call to recv() first.
+        Raises StoppedError when called on a stopped process.
         """
 
+        if not self.running:
+            logger.error("Background process was closed previously!")
+            raise BackgroundProcess.StoppedError()
+
+        if self._busy:
+            logger.error("Sending data without receiving previous output!")
+            raise BackgroundProcess.MultipleSendError()
+
+        self._pipe.send({"args": args, "kwargs": kwargs})
+        self._busy = True
+
+    def poll(self) -> bool:
+        """Check if data is available for recv() from background task."""
+        if not self.running:
+            logger.error("Background process was closed previously!")
+            raise BackgroundProcess.StoppedError()
+        return self._pipe.poll()
+
+    def recv(self) -> Any:
+        """Returns results from background process.
+
+        Blocks until results are available.
+
+        Raises any Exception that occurred in backgrund process.
+        Raises NothingToReceiveError when called without previous call to send().
+        Raises StoppedError when called on a stopped process.
+        """
+
+        if not self.running:
+            logger.error("Background process was closed previously!")
+            raise BackgroundProcess.StoppedError()
+
+        if not self._busy:
+            logger.error("Querying background process without submitted data!")
+            raise BackgroundProcess.NothingToReceiveError()
+
+        try:
+            results = self._pipe.recv()
+        except EOFError:
+            logger.error("Pipe was closed from background process!")
+            raise BackgroundProcess.StoppedError()
+
+        if isinstance(results, Exception):
+            logger.error(f"Error in background process:\n{results}")
+            raise results
+
+        self._busy = False
+        return results
+
+    def cancel(self, timeout=-1):
+        """Stop process as soon as current task is finished."""
+
+        self._should_terminate_flag.value = 1
+        if self.running:
+            self._process.join(timeout)
+        self._running = False
+
+    @staticmethod
+    def _install_sigint_interception():
         def interrupt_handler(sig, frame):
             import traceback
 
             trace = traceback.format_stack(f=frame)
-            logger.debug(f"Caught signal {sig} in:\n" + "".join(trace))
-            # NOTE: Interrupt is handled in world/service/player which are responsible
-            # for shutting down the background process properly
+            logger.debug(f"Caught (and dropping) signal {sig} in:\n" + "".join(trace))
 
         signal.signal(signal.SIGINT, interrupt_handler)
-        try:
-            self._change_logging_behavior()
-            logger.debug("Entering _wrapper")
 
-            for datum in generator(*args, **kwargs):
-                if _should_terminate_flag.value:
-                    raise EarlyCancellationError("Task was cancelled")
-                pipe.send(datum)
-        except Exception as e:
-            pipe.send(e)
-            if not isinstance(e, EarlyCancellationError):
-                import traceback
+    @staticmethod
+    def _worker(
+        function: Callable,
+        pipe: mp.connection.Connection,
+        should_terminate_flag: mp.Value,
+    ):
+        # Intercept SIGINT (ctrl-c), do required cleanup in foreground process!
+        BackgroundProcess._install_sigint_interception()
 
-                logger.info(traceback.format_exc())
-        else:
-            pipe.send(StopIteration())
-        finally:
-            pipe.close()
-            logger.debug("Exiting _wrapper")
-
-    def _prepare_wrapper_args(self, *args):
-        return list(args)
-
-    def _change_logging_behavior(self):
-        pass
-
-    def fetch(self):
-        """Fetches progress and available results from background"""
-        if self.completed or self.canceled:
-            return
-
-        while self.pipe.poll(0):
+        while not should_terminate_flag.value:
             try:
-                datum = self.pipe.recv()
+                params = pipe.recv()
+                args = params["args"]
+                kwargs = params["kwargs"]
             except EOFError:
-                logger.debug("Process canceled be user.")
-                self._canceled = True
-                return
-            else:
-                if isinstance(datum, StopIteration):
-                    self._completed = True
-                    return
-                elif isinstance(datum, EarlyCancellationError):
-                    self._canceled = True
-                    return
-                elif isinstance(datum, Exception):
-                    raise datum
-                else:
-                    yield datum
+                logger.info("Pipe was closed from foreground process .")
+                break
 
-    def cancel(self, timeout=1):
-        if not (self.completed or self.canceled):
-            self._should_terminate_flag.value = True
-            for x in self.fetch():
-                # fetch to flush pipe to allow process to react to cancel comand.
-                pass
-        if self.process is not None:
-            self.process.join(timeout)
-            self.process = None
+            try:
+                results = function(*args, **kwargs)
+            except Exception as e:
+                pipe.send(e)
+                logger.error(
+                    f"Error executing background process with parameters {params}:\n{e}"
+                )
+                break
 
-    @property
-    def completed(self):
-        return self._completed
+            pipe.send(results)
+        else:
+            logger.info("Background process received termination signal.")
 
-    @property
-    def canceled(self):
-        return self._canceled
+        logger.info("Stopping background process.")
+        pipe.close()

--- a/pye3d/detector_3d.py
+++ b/pye3d/detector_3d.py
@@ -60,6 +60,17 @@ class Detector3D(object):
 
         self.debug_result = {}
 
+    def cleanup(self):
+        """
+        Cleanup detector after usage.
+
+        This will shut down the continuously running background process. Use this
+        function when you are done using the detector, but your application continues.
+        Using the detector again after cleanup() will result in errors. Prefer to call
+        reset() if you want to simply re-initialize and continue using the detector.
+        """
+        self.task.cancel()
+
     def update_and_detect(
         self, pupil_datum, frame, refraction_toggle=True, debug_toggle=False
     ):

--- a/pye3d/detector_3d.py
+++ b/pye3d/detector_3d.py
@@ -41,6 +41,7 @@ class Detector3D(object):
             "threshold_swirski": 0.7,
             "threshold_kalman": 0.98,
         },
+        log_handler=None,
     ):
         self.settings = settings
 
@@ -52,7 +53,10 @@ class Detector3D(object):
         self.kalman_filter = KalmanFilter()
         self.last_kalman_call = -1
 
-        self.task = BackgroundProcess(TwoSphereModel.deep_sphere_estimate)
+        self._external_log_handler = log_handler
+        self.task = BackgroundProcess(
+            TwoSphereModel.deep_sphere_estimate, self._external_log_handler
+        )
 
         self.debug_result = {}
 
@@ -329,4 +333,6 @@ class Detector3D(object):
         self.task.cancel()
         self.currently_optimizing = False
         self.new_observations = False
-        self.task = BackgroundProcess(TwoSphereModel.deep_sphere_estimate)
+        self.task = BackgroundProcess(
+            TwoSphereModel.deep_sphere_estimate, log_handler=self._external_log_handler
+        )

--- a/pye3d/two_sphere_model.py
+++ b/pye3d/two_sphere_model.py
@@ -171,7 +171,7 @@ class TwoSphereModel(object):
         )
         sphere_center = np.linalg.pinv(sum_aux_3d[:3, :3]) @ sum_aux_3d[:3, 3]
 
-        yield sphere_center
+        return sphere_center
 
     # GAZE PREDICTION
     def _extract_unproject_disambiguate(self, pupil_datum):


### PR DESCRIPTION
This PR replaces TaskProxy with a more appropriate background process implementation:

- the background process runs the entire time and has a simple function (not a generator anymore) as target
- every time it receives input (`.send()`), it runs the function with the input in the background
- once the function is ready (check with `.poll()`), the output can be queried (`.recv()`)
- a log handler can be passed which receives logs from the background task

This makes the interface clearer for the purpose of Pye3D and also fixes potential overhead by repeatedly spinning up new TaskProxy processes.

To test this in Pupil, use either the [pye3d branch](https://github.com/pupil-labs/pupil/tree/pye3d) or, to also get logs from the background process, use the [pye3d-background-logging branch](https://github.com/pupil-labs/pupil/tree/pye3d-background-logging), which hooks up Pupil's root logger.
You will have to install this branch into the Python environment that you use to run Pupil:
```
pip install https://github.com/pupil-labs/pye3d-detector/archive/background-process.zip
```

**Open Questions**
1. If something breaks or throws an exception, the BackgroundProcess just stops to work until restarted externally. Theoretically, I could also implement that it restarts itself. Not sure if we should do this here or in the wrapping application (e.g. Pupil).

**TODO**
- [x] Needs explicit `.cleanup()` function on detector to kill the background process.