### PR TITLE
Slippage compensation

### DIFF
--- a/pye3d/camera.py
+++ b/pye3d/camera.py
@@ -1,0 +1,7 @@
+from typing import Tuple
+
+
+class CameraModel:
+    def __init__(self, focal_length: float, resolution: Tuple[float, float]):
+        self.focal_length = focal_length
+        self.resolution = resolution

--- a/pye3d/detector_3d.py
+++ b/pye3d/detector_3d.py
@@ -158,7 +158,6 @@ class Detector3D(object):
         # pupil_circle <-> kalman filter
         # either improve prediction or improve filter
         pupil_circle_kalman = self._predict_from_kalman_filter(pupil_datum["timestamp"])
-        self.used_3dsearch = False
         if observation.confidence > self.settings["threshold_kalman"]:
             # high confidence: use to correct kalman filter
             self._correct_kalman_filter(pupil_circle)
@@ -168,7 +167,6 @@ class Detector3D(object):
                 frame, best_guess=pupil_circle_kalman
             )
             # TODO: adjust observation.confidence
-            self.used_3dsearch = True
 
         # apply refraction correction
         if apply_refraction_correction:

--- a/pye3d/detector_3d.py
+++ b/pye3d/detector_3d.py
@@ -272,9 +272,11 @@ class Detector3D(object):
         return pupil_circle_kalman
 
     def _correct_kalman_filter(self, observed_pupil_circle: Circle):
-        if observed_pupil_circle is not None:
-            phi, theta, r = observed_pupil_circle.spherical_representation()
-            self.kalman_filter.correct(phi, theta, r)
+        if observed_pupil_circle.is_null():
+            return
+
+        phi, theta, r = observed_pupil_circle.spherical_representation()
+        self.kalman_filter.correct(phi, theta, r)
 
     def _predict_from_3d_search(self, frame: np.ndarray, best_guess: Circle) -> Circle:
         if best_guess.is_null():

--- a/pye3d/detector_3d.py
+++ b/pye3d/detector_3d.py
@@ -113,7 +113,9 @@ class Detector3D(object):
                 _ = self.task.recv()
                 self._discard_next_task_result = False
             else:
-                result, debug_info = self.task.recv()
+                result, cutoff, self.debug_info = self.task.recv()
+                if cutoff is not None:
+                    self.two_sphere_model.observation_storage.purge(cutoff)
                 self._process_sphere_center_estimate(result)
 
         # SPHERE CENTER UPDATE

--- a/pye3d/detector_3d.py
+++ b/pye3d/detector_3d.py
@@ -395,6 +395,12 @@ class Detector3D(object):
         bin_data = np.flip(bin_data, axis=0)
         debug_info["bin_data"] = bin_data.tolist()
 
+        # TODO: Pupil visualizer_pye3d.py attempts to draw Dierkes lines. Currently we
+        # don't calculate them here, we could probably do that again. Based on which
+        # model? Might be hard to do when things run in the background. We might have to
+        # remove this from the visualizer_pye3d.py
+        debug_info["Dierkes_lines"] = []
+
         return debug_info
 
     def reset(self):

--- a/pye3d/detector_3d.py
+++ b/pye3d/detector_3d.py
@@ -70,28 +70,34 @@ def circle2dict(circle: Circle, flip_y: bool = True) -> Dict:
 class Detector3D(object):
     def __init__(
         self,
-        settings={
-            "focal_length": 283.0,
-            "resolution": (192, 192),
-            "threshold_swirski": 0.7,
-            "threshold_kalman": 0.98,
-            "threshold_short_term": 0.8,
-            "threshold_long_term": 0.98,
-            "long_term_buffer_size": 10,
-            "long_term_forget_time": 5,
-            "long_term_forget_observations": 100,
-        },
+        focal_length=283.0,
+        resolution=(192, 192),
+        threshold_swirski=0.7,
+        threshold_kalman=0.98,
+        threshold_short_term=0.8,
+        threshold_long_term=0.98,
+        long_term_buffer_size=10,
+        long_term_forget_time=5,
+        long_term_forget_observations=100,
     ):
-        self.settings = settings
-        self.camera = CameraModel(
-            focal_length=settings["focal_length"], resolution=settings["resolution"]
-        )
+        self.settings = {
+            "focal_length": focal_length,
+            "resolution": resolution,
+            "threshold_swirski": threshold_swirski,
+            "threshold_kalman": threshold_kalman,
+            "threshold_short_term": threshold_short_term,
+            "threshold_long_term": threshold_long_term,
+            "long_term_buffer_size": long_term_buffer_size,
+            "long_term_forget_time": long_term_forget_time,
+            "long_term_forget_observations": long_term_forget_observations,
+        }
+        self.camera = CameraModel(focal_length=focal_length, resolution=resolution)
 
         self.short_term_model = TwoSphereModel(
             camera=self.camera,
             storage=BufferedObservationStorage(
                 camera=self.camera,
-                confidence_threshold=settings["threshold_short_term"],
+                confidence_threshold=threshold_short_term,
                 buffer_length=10,
             ),
         )
@@ -99,18 +105,18 @@ class Detector3D(object):
             camera=self.camera,
             storage=BinBufferedObservationStorage(
                 camera=self.camera,
-                confidence_threshold=settings["threshold_long_term"],
+                confidence_threshold=threshold_long_term,
                 n_bins_horizontal=10,
-                bin_buffer_length=settings["long_term_buffer_size"],
-                forget_min_observations=settings["long_term_forget_observations"],
-                forget_min_time=settings["long_term_forget_time"],
+                bin_buffer_length=long_term_buffer_size,
+                forget_min_observations=long_term_forget_observations,
+                forget_min_time=long_term_forget_time,
             ),
         )
         self.ultra_long_term_model = TwoSphereModel(
             camera=self.camera,
             storage=BinBufferedObservationStorage(
                 camera=self.camera,
-                confidence_threshold=settings["threshold_long_term"],
+                confidence_threshold=threshold_long_term,
                 n_bins_horizontal=10,
                 bin_buffer_length=100,
             ),

--- a/pye3d/detector_3d.py
+++ b/pye3d/detector_3d.py
@@ -425,6 +425,16 @@ class Detector3D(object):
             result["phi"] = 0.0
 
         result["used_3dsearch"] = self.used_3dsearch
+        result["long_term_n_observations"] = len(
+            self.long_term_model.storage.observations
+        )
+        result["long_term_n_bins"] = len(self.long_term_model.storage._by_bin)
+
+        result["long_term_oldest"] = (
+            float("inf")
+            if (len(self.long_term_model.storage.observations) <= 0)
+            else self.long_term_model.storage.observations[0].timestamp
+        )
 
         return result
 

--- a/pye3d/detector_3d.py
+++ b/pye3d/detector_3d.py
@@ -162,7 +162,7 @@ class Detector3D(object):
 
         # apply refraction correction
         if apply_refraction_correction:
-            pupil_circle = self.short_term_model.apply_refraction_correction(
+            pupil_circle = self.long_term_model.apply_refraction_correction(
                 pupil_circle
             )
             sphere_center = self.long_term_model.corrected_sphere_center

--- a/pye3d/detector_3d.py
+++ b/pye3d/detector_3d.py
@@ -357,7 +357,10 @@ class Detector3D(object):
 
         result["confidence"] = observation.confidence
         result["confidence_2d"] = observation.confidence_2d
-        # TODO: remove model confidence? Will require adjustment in Pupil!
+        # TODO: model_confidence is currently require in Pupil for visualization
+        # (eyeball outline alpha), but we don't yet have a way of estimating the model
+        # confidence. Either remove this and cleanup the visualization in Pupil or come
+        # up with a measure for model confidence.
         result["model_confidence"] = 1.0
 
         phi, theta = cart2sph(pupil_circle.normal)

--- a/pye3d/detector_3d.py
+++ b/pye3d/detector_3d.py
@@ -167,6 +167,7 @@ class Detector3D(object):
             pupil_circle = self._predict_from_3d_search(
                 frame, best_guess=pupil_circle_kalman
             )
+            # TODO: adjust observation.confidence
             self.used_3dsearch = True
 
         # apply refraction correction
@@ -345,11 +346,10 @@ class Detector3D(object):
         result["ellipse"] = ellipse2dict(projected_pupil_circle)
         result["diameter"] = projected_pupil_circle.major_radius
 
+        result["confidence"] = observation.confidence
+        result["confidence_2d"] = observation.confidence_2d
         # TODO: remove model confidence? Will require adjustment in Pupil!
         result["model_confidence"] = 1.0
-        # TODO: Adjust confidence measure when observation invalid or when having done
-        # 3D search from kalman result
-        result["confidence"] = observation.confidence
 
         phi, theta = cart2sph(pupil_circle.normal)
         if not np.any(np.isnan([phi, theta])):

--- a/pye3d/detector_3d.py
+++ b/pye3d/detector_3d.py
@@ -85,7 +85,7 @@ class Detector3D(object):
         self.update_models(observation)
 
         # make initial predictions
-        pupil_circle = Circle.create_invalid()
+        pupil_circle = Circle.null()
         if observation.confidence > self.settings["threshold_swirski"]:
             pupil_circle = self.short_term_model.predict_pupil_circle(observation)
         sphere_center = self.short_term_model.sphere_center
@@ -172,7 +172,7 @@ class Detector3D(object):
             self.kalman_filter.correct(phi, theta, r)
 
     def _predict_from_3d_search(self, frame: np.ndarray, best_guess: Circle) -> Circle:
-        if best_guess.invalid:
+        if best_guess.is_null():
             return best_guess
 
         frame, frame_roi, edge_frame, edges, roi = get_edges(

--- a/pye3d/detector_3d.py
+++ b/pye3d/detector_3d.py
@@ -139,6 +139,7 @@ class Detector3D(object):
         self.update_models(observation)
 
         # make initial predictions
+        # TODO: extract into function
         pupil_circle_short_term = Circle.null()
         pupil_circle_long_term = Circle.null()
         if observation.confidence > self.settings["threshold_swirski"]:
@@ -148,12 +149,13 @@ class Detector3D(object):
             pupil_circle_long_term = self.long_term_model.predict_pupil_circle(
                 observation
             )
-        sphere_center = self.long_term_model.sphere_center
         pupil_circle = Circle(
             pupil_circle_long_term.center,
             pupil_circle_short_term.normal,
             pupil_circle_long_term.radius,
         )
+
+        sphere_center = self.long_term_model.sphere_center
 
         # pupil_circle <-> kalman filter
         # either improve prediction or improve filter
@@ -229,6 +231,7 @@ class Detector3D(object):
         except Exception as e:
             logger.error("Error updating models:")
             logger.error(e)
+            # TODO: Known issues: Can raise SVD error. Remove re-raise.
             raise e
         self.ult_model_update_counter += 1
 

--- a/pye3d/detector_3d.py
+++ b/pye3d/detector_3d.py
@@ -9,6 +9,7 @@ See COPYING and COPYING.LESSER for license details.
 ---------------------------------------------------------------------------~(*)
 """
 import logging
+import traceback
 from typing import Dict
 
 import numpy as np
@@ -201,7 +202,7 @@ class Detector3D(object):
             # Known issues:
             # - Can raise numpy.linalg.LinAlgError: SVD did not converge
             logger.error("Error updating models:")
-            logger.error(e)
+            logger.debug(traceback.format_exc())
 
         self.ult_counter += 1
 

--- a/pye3d/detector_3d.py
+++ b/pye3d/detector_3d.py
@@ -99,6 +99,7 @@ class Detector3D(object):
             self.debug_info = {
                 "incoming": spherical(current_circle_3d),
                 "predicted": spherical(pupil_circle),
+                "short_term_center": self.short_term_model.sphere_center,
             }
 
         pupil_circle_kalman = self._predict_from_kalman_filter(

--- a/pye3d/detector_3d.py
+++ b/pye3d/detector_3d.py
@@ -62,7 +62,7 @@ def circle2dict(circle: Circle, flip_y: bool = True) -> Dict:
             flip * circle.normal[1],
             circle.normal[2],
         ),
-        "radius": circle.radius,
+        "radius": float(circle.radius),
     }
 
 
@@ -154,7 +154,7 @@ class Detector3D(object):
                 x, y, z = normalize(circle.normal)
                 theta = math.atan2(y, x)
                 phi = math.acos(z)
-                return np.array([theta, phi])
+                return [theta, phi]
 
             incoming = self.long_term_model._disambiguate_circle_3d_pair(
                 observation.circle_3d_pair
@@ -184,10 +184,12 @@ class Detector3D(object):
             self.debug_info = {
                 "incoming": spherical(incoming),
                 "predicted": spherical(pupil_circle),
-                "short_term_center": self.short_term_model.sphere_center,
+                "short_term_center": list(self.short_term_model.sphere_center),
                 "projected_short_term": ellipse2dict(projected_short_term),
                 "projected_long_term": ellipse2dict(projected_long_term),
-                "bins": bins,
+                "bins": bins.tolist(),
+                "px_per_bin": bin_storage.pixels_per_bin,
+                "Dierkes_lines": [],
             }
 
         if debug:

--- a/pye3d/detector_3d.py
+++ b/pye3d/detector_3d.py
@@ -94,7 +94,6 @@ class Detector3D(object):
         self.short_term_model = TwoSphereModel(
             camera=self.camera,
             storage=BufferedObservationStorage(
-                camera=self.camera,
                 confidence_threshold=threshold_short_term,
                 buffer_length=10,
             ),

--- a/pye3d/detector_3d.py
+++ b/pye3d/detector_3d.py
@@ -409,4 +409,6 @@ class Detector3D(object):
     def reset(self):
         self.short_term_model.reset()
         self.long_term_model.reset()
+        self.ultra_long_term_model.reset()
+        self.ult_counter = 0
         self.kalman_filter = KalmanFilter()

--- a/pye3d/detector_3d.py
+++ b/pye3d/detector_3d.py
@@ -171,6 +171,9 @@ class Detector3D(object):
 
         # apply refraction correction
         if apply_refraction_correction:
+            # TODO: Visualizing this in Pupil is kind of weird, as it does not align
+            # well with what the user sees. Maybe we should also always add in the
+            # un-corrected data only for visualization?
             pupil_circle = self.long_term_model.apply_refraction_correction(
                 pupil_circle
             )

--- a/pye3d/detector_3d.py
+++ b/pye3d/detector_3d.py
@@ -141,10 +141,21 @@ class Detector3D(object):
         self.update_models(observation)
 
         # make initial predictions
-        pupil_circle = Circle.null()
+        pupil_circle_short_term = Circle.null()
+        pupil_circle_long_term = Circle.null()
         if observation.confidence > self.settings["threshold_swirski"]:
-            pupil_circle = self.short_term_model.predict_pupil_circle(observation)
+            pupil_circle_short_term = self.short_term_model.predict_pupil_circle(
+                observation
+            )
+            pupil_circle_long_term = self.long_term_model.predict_pupil_circle(
+                observation
+            )
         sphere_center = self.long_term_model.sphere_center
+        pupil_circle = Circle(
+            pupil_circle_long_term.center,
+            pupil_circle_short_term.normal,
+            pupil_circle_long_term.radius,
+        )
 
         # pupil_circle <-> kalman filter
         # either improve prediction or improve filter

--- a/pye3d/detector_3d.py
+++ b/pye3d/detector_3d.py
@@ -118,7 +118,9 @@ class Detector3D(object):
                 camera=self.camera,
                 confidence_threshold=threshold_long_term,
                 n_bins_horizontal=10,
-                bin_buffer_length=100,
+                bin_buffer_length=10,
+                forget_min_observations=20,
+                forget_min_time=60,
             ),
         )
 

--- a/pye3d/detector_3d.py
+++ b/pye3d/detector_3d.py
@@ -116,8 +116,8 @@ class Detector3D(object):
                 camera=self.camera,
                 confidence_threshold=threshold_long_term,
                 n_bins_horizontal=10,
-                bin_buffer_length=10,
-                forget_min_observations=20,
+                bin_buffer_length=long_term_buffer_size,
+                forget_min_observations=long_term_forget_observations * 2,
                 forget_min_time=60,
             ),
         )

--- a/pye3d/geometry/primitives.py
+++ b/pye3d/geometry/primitives.py
@@ -58,12 +58,11 @@ class Circle(Primitive):
         phi, theta = cart2sph(self.normal)
         return phi, theta, self.radius
 
-    @property
-    def invalid(self):
+    def is_null(self):
         return self.radius <= 0.0
 
     @staticmethod
-    def create_invalid() -> "Circle":
+    def null() -> "Circle":
         return Circle(radius=0.0)
 
 

--- a/pye3d/geometry/primitives.py
+++ b/pye3d/geometry/primitives.py
@@ -49,7 +49,7 @@ class Line(Primitive):
 
 
 class Circle(Primitive):
-    def __init__(self, center=[0, 0, 0], normal=[0, 0, -1], radius=0):
+    def __init__(self, center=[0.0, 0.0, 0.0], normal=[0.0, 0.0, -1.0], radius=0.0):
         self.center = np.array(center, dtype=np.float)
         self.normal = np.array(normal, dtype=np.float)
         self.radius = radius
@@ -58,11 +58,13 @@ class Circle(Primitive):
         phi, theta = cart2sph(self.normal)
         return phi, theta, self.radius
 
-    def __bool__(self):
-        if self.radius > 0:
-            return True
-        else:
-            return False
+    @property
+    def invalid(self):
+        return self.radius <= 0.0
+
+    @staticmethod
+    def create_invalid() -> "Circle":
+        return Circle(radius=0.0)
 
 
 class Ellipse(Primitive):
@@ -140,17 +142,15 @@ class Conic(Primitive):
             self.B = 2.0 * ax * ay / a2 - 2.0 * ax * ay / b2
             self.C = ay * ay / a2 + ax * ax / b2
             self.D = (
-                (-2 * ax * ay * ellipse.center[1] - 2 * ax * ax * ellipse.center[0])
-                / a2
-                + (2 * ax * ay * ellipse.center[1] - 2 * ay * ay * ellipse.center[0])
-                / b2
-            )
+                -2 * ax * ay * ellipse.center[1] - 2 * ax * ax * ellipse.center[0]
+            ) / a2 + (
+                2 * ax * ay * ellipse.center[1] - 2 * ay * ay * ellipse.center[0]
+            ) / b2
             self.E = (
-                (-2 * ax * ay * ellipse.center[0] - 2 * ay * ay * ellipse.center[1])
-                / a2
-                + (2 * ax * ay * ellipse.center[0] - 2 * ax * ax * ellipse.center[1])
-                / b2
-            )
+                -2 * ax * ay * ellipse.center[0] - 2 * ay * ay * ellipse.center[1]
+            ) / a2 + (
+                2 * ax * ay * ellipse.center[0] - 2 * ax * ax * ellipse.center[1]
+            ) / b2
             self.F = (
                 (
                     2 * ax * ay * ellipse.center[0] * ellipse.center[1]

--- a/pye3d/observation.py
+++ b/pye3d/observation.py
@@ -83,6 +83,7 @@ class Observation(object):
 
 class ObservationStorage:
     def __init__(self, *, camera: CameraModel, confidence_threshold: float):
+        # TODO: move these out of base class
         self.camera = camera
         self.confidence_threshold = confidence_threshold
 
@@ -101,6 +102,9 @@ class ObservationStorage:
     @abstractmethod
     def count(self) -> int:
         pass
+
+
+# TODO: Naive Storage for Kai! :)
 
 
 class BufferedObservationStorage(ObservationStorage):

--- a/pye3d/observation.py
+++ b/pye3d/observation.py
@@ -76,10 +76,6 @@ class Observation(object):
         direction = self.circle_3d_pair[i].center
         return Line(origin, direction)
 
-    def __bool__(self):
-        # TODO!
-        raise RuntimeError("NONONO!")
-
 
 class ObservationStorage:
     def __init__(self, *, camera: CameraModel, confidence_threshold: float):

--- a/pye3d/observation.py
+++ b/pye3d/observation.py
@@ -96,6 +96,10 @@ class ObservationStorage:
     def clear(self):
         pass
 
+    @abstractmethod
+    def count(self) -> int:
+        pass
+
 
 class BufferedObservationStorage(ObservationStorage):
     def __init__(self, *, buffer_length: int, **kwargs):
@@ -117,6 +121,9 @@ class BufferedObservationStorage(ObservationStorage):
     def clear(self):
         self._storage.clear()
 
+    def count(self) -> int:
+        return len(self._storage)
+
 
 class BinBufferedObservationStorage(ObservationStorage):
     def __init__(self, *, n_bins_horizontal: int, bin_buffer_length: int, **kwargs):
@@ -137,6 +144,9 @@ class BinBufferedObservationStorage(ObservationStorage):
             return
 
         idx = self._get_bin(observation)
+        if idx < 0 or idx >= len(self._storage):
+            print(f"INDEX OUT OF BOUNDS: {idx}")
+            return
         self._storage[idx].append(observation)
 
     @property
@@ -147,6 +157,9 @@ class BinBufferedObservationStorage(ObservationStorage):
     def clear(self):
         for _bin in self._storage:
             _bin.clear()
+
+    def count(self) -> int:
+        return sum(len(_bin) for _bin in self._storage)
 
     def _get_bin(self, observation: Observation) -> int:
         x, y = (

--- a/pye3d/observation.py
+++ b/pye3d/observation.py
@@ -8,19 +8,18 @@ Lesser General Public License (LGPL v3.0).
 See COPYING and COPYING.LESSER for license details.
 ---------------------------------------------------------------------------~(*)
 """
+from abc import abstractmethod, abstractproperty
 from collections import deque
 from itertools import chain
 from math import floor
-from abc import abstractmethod, abstractproperty
+from typing import Sequence
 
 import numpy as np
 
-from typing import Sequence
-
-from .constants import _EYE_RADIUS_DEFAULT
-from .geometry.primitives import Line, Ellipse
-from .geometry.projections import project_line_into_image_plane, unproject_ellipse
 from .camera import CameraModel
+from .constants import _EYE_RADIUS_DEFAULT
+from .geometry.primitives import Ellipse, Line
+from .geometry.projections import project_line_into_image_plane, unproject_ellipse
 
 
 class Observation(object):
@@ -38,17 +37,18 @@ class Observation(object):
         self.aux_3d = None
         self.invalid = True
 
-        unprojection = unproject_ellipse(ellipse, focal_length)
-        if not unprojection:
+        circle_3d_pair = unproject_ellipse(ellipse, focal_length)
+        if not circle_3d_pair:
             # unprojecting ellipse failed, invalid observation!
             return
 
         self.invalid = False
+        self.circle_3d_pair = circle_3d_pair
 
         self.gaze_3d_pair = [
             Line(
-                self.circle_3d_pair[i].center,
-                self.circle_3d_pair[i].center + self.circle_3d_pair[i].normal,
+                circle_3d_pair[i].center,
+                circle_3d_pair[i].center + circle_3d_pair[i].normal,
             )
             for i in [0, 1]
         ]

--- a/pye3d/observation.py
+++ b/pye3d/observation.py
@@ -162,15 +162,15 @@ class BinBufferedObservationStorage(ObservationStorage):
         if idx not in self._by_bin:
             self._by_bin[idx] = SortedList(key=lambda obs: obs.timestamp)
 
-        # manage within-bin forgetting
-        _bin: SortedList = self._by_bin[idx]
-        while len(_bin) >= self.bin_buffer_length:
-            old = _bin.pop(0)
-            self._by_time.remove(old)
-
         # add to both lookup structures
+        _bin: SortedList = self._by_bin[idx]
         _bin.add(observation)
         self._by_time.add(observation)
+
+        # manage within-bin forgetting
+        while len(_bin) > self.bin_buffer_length:
+            old = _bin.pop(0)
+            self._by_time.remove(old)
 
         # manage across-bin forgetting
         if self.forget_min_observations is None or self.forget_min_time is None:

--- a/pye3d/observation.py
+++ b/pye3d/observation.py
@@ -78,11 +78,6 @@ class Observation(object):
 
 
 class ObservationStorage:
-    def __init__(self, *, camera: CameraModel, confidence_threshold: float):
-        # TODO: move these out of base class
-        self.camera = camera
-        self.confidence_threshold = confidence_threshold
-
     @abstractmethod
     def add(self, observation: Observation):
         pass
@@ -104,8 +99,8 @@ class ObservationStorage:
 
 
 class BufferedObservationStorage(ObservationStorage):
-    def __init__(self, *, buffer_length: int, **kwargs):
-        super().__init__(**kwargs)
+    def __init__(self, confidence_threshold: float, buffer_length: int):
+        self.confidence_threshold = confidence_threshold
         self._storage = deque(maxlen=buffer_length)
 
     def add(self, observation: Observation):
@@ -130,14 +125,15 @@ class BufferedObservationStorage(ObservationStorage):
 class BinBufferedObservationStorage(ObservationStorage):
     def __init__(
         self,
-        *,
+        camera: CameraModel,
+        confidence_threshold: float,
         n_bins_horizontal: int,
         bin_buffer_length: int,
         forget_min_observations: Optional[int] = None,
         forget_min_time: Optional[float] = None,
-        **kwargs,
     ):
-        super().__init__(**kwargs)
+        self.camera = camera
+        self.confidence_threshold = confidence_threshold
         self.bin_buffer_length = bin_buffer_length
         self.forget_min_observations = forget_min_observations
         self.forget_min_time = forget_min_time

--- a/pye3d/observation.py
+++ b/pye3d/observation.py
@@ -95,7 +95,24 @@ class ObservationStorage:
         pass
 
 
-# TODO: Naive Storage for Kai! :)
+class BasicStorage(ObservationStorage):
+    def __init__(self):
+        self._storage = []
+
+    def add(self, observation: Observation):
+        if observation.invalid:
+            return
+        self._storage.append(observation)
+
+    @property
+    def observations(self) -> Sequence[Observation]:
+        return self._storage
+
+    def clear(self):
+        self._storage.clear()
+
+    def count(self) -> int:
+        return len(self._storage)
 
 
 class BufferedObservationStorage(ObservationStorage):

--- a/pye3d/observation.py
+++ b/pye3d/observation.py
@@ -27,7 +27,8 @@ class Observation(object):
         self, ellipse: Ellipse, confidence: float, timestamp: float, focal_length: float
     ):
         self.ellipse = ellipse
-        self.confidence = confidence
+        self.confidence_2d = confidence
+        self.confidence = 0.0
         self.timestamp = timestamp
 
         self.circle_3d_pair = None
@@ -43,6 +44,7 @@ class Observation(object):
             return
 
         self.invalid = False
+        self.confidence = self.confidence_2d
         self.circle_3d_pair = circle_3d_pair
 
         self.gaze_3d_pair = [

--- a/pye3d/two_sphere_model.py
+++ b/pye3d/two_sphere_model.py
@@ -116,54 +116,6 @@ class TwoSphereModel(object):
 
         return sphere_center
 
-    @staticmethod
-    def deep_sphere_estimate(
-        _observations: Sequence[Observation],
-    ) -> Tuple[np.ndarray, float, Dict[str, Any]]:
-        # TODO: delete
-        # https://silo.tips/download/least-squares-intersection-of-lines
-        # https://www.researchgate.net/publication/333490770_A_fast_approach_to_refraction-aware_eye-model_fitting_and_gaze_prediction
-
-        # 2D WITH LONG TERM
-        observations = list(_observations)
-        aux_2d = np.array([obs.aux_2d for obs in observations])
-        gaze_2d = np.array(
-            [[*obs.gaze_2d.origin, *obs.gaze_2d.direction] for obs in observations]
-        )
-        # Estimate projected sphere center by nearest intersection of 2d gaze lines
-        sum_aux_2d = aux_2d.sum(axis=0)
-        projected_sphere_center = np.linalg.pinv(sum_aux_2d[:2, :2]) @ sum_aux_2d[:2, 2]
-
-        # 3D WITH SHORT TERM
-        observations = list(_observations)
-        aux_3d = np.array([obs.aux_3d for obs in observations])
-        gaze_2d = np.array(
-            [[*obs.gaze_2d.origin, *obs.gaze_2d.direction] for obs in observations]
-        )
-
-        # Disambiguate Dierkes lines
-        # We want gaze_2d to points towards the sphere center. gaze_2d was collected
-        # from Dierkes[0]. If it points into the correct direction, we know that
-        # Dierkes[0] is the correct one to use, otherwise we need to use Dierkes[1]. We
-        # can check that with the sign of the dot product.
-        gaze_2d_origins = gaze_2d[:, :2]
-        gaze_2d_directions = gaze_2d[:, 2:]
-        gaze_2d_towards_center = gaze_2d_origins - projected_sphere_center
-
-        dot_products = np.sum(gaze_2d_towards_center * gaze_2d_directions, axis=1)
-        disambiguation_indices = np.where(dot_products < 0, 1, 0)
-
-        observation_indices = np.arange(len(disambiguation_indices))
-        aux_3d_disambiguated = aux_3d[observation_indices, disambiguation_indices, :, :]
-
-        # Estimate sphere center by nearest intersection of Dierkes lines
-        sum_aux_3d = aux_3d_disambiguated.sum(axis=0)
-        sphere_center = np.linalg.pinv(sum_aux_3d[:3, :3]) @ sum_aux_3d[:3, 3]
-
-        print(sphere_center)
-
-        return sphere_center
-
     # GAZE PREDICTION
     def _extract_unproject_disambiguate(self, pupil_datum):
         ellipse = self._extract_ellipse(pupil_datum)

--- a/pye3d/two_sphere_model.py
+++ b/pye3d/two_sphere_model.py
@@ -56,6 +56,10 @@ class TwoSphereModel(object):
     def add_observation(self, observation: Observation):
         self.storage.add(observation)
 
+    @property
+    def n_observations(self) -> int:
+        return self.storage.count()
+
     def set_sphere_center(self, new_sphere_center):
         self.sphere_center = new_sphere_center
         self.corrected_sphere_center = self.refractionizer.correct_sphere_center(

--- a/pye3d/two_sphere_model.py
+++ b/pye3d/two_sphere_model.py
@@ -46,13 +46,6 @@ class TwoSphereModel(object):
             np.asarray([[*self.sphere_center]])
         )[0]
 
-        self.debug_info = {
-            "cost": -1.0,
-            "residuals": [],
-            "angles": [],
-            "Dierkes_lines": [],
-        }
-
     def add_observation(self, observation: Observation):
         self.storage.add(observation)
 
@@ -248,9 +241,3 @@ class TwoSphereModel(object):
     def reset(self):
         self.sphere_center = np.array([0.0, 0.0, 35.0])
         self.storage.clear()
-        self.debug_info = {
-            "cost": -1.0,
-            "residuals": [],
-            "angles": [],
-            "dierkes_lines": [],
-        }

--- a/pye3d/two_sphere_model.py
+++ b/pye3d/two_sphere_model.py
@@ -14,6 +14,7 @@ from typing import Any, Dict, Sequence, Tuple
 import numpy as np
 import numpy.linalg
 
+from .camera import CameraModel
 from .constants import _EYE_RADIUS_DEFAULT
 from .geometry.intersections import nearest_point_on_sphere_to_line
 from .geometry.primitives import Circle, Line
@@ -25,7 +26,6 @@ from .geometry.projections import (
 from .geometry.utilities import normalize
 from .observation import Observation, ObservationStorage
 from .refraction import Refractionizer
-from .camera import CameraModel
 
 logger = logging.getLogger(__name__)
 
@@ -198,8 +198,6 @@ class TwoSphereModel(object):
         self, observation: Observation, use_unprojection: bool = False
     ) -> Circle:
         if observation.invalid:
-            return Circle.create_invalid()
-        if observation.confidence < self.settings["threshold_swirski"]:
             return Circle.create_invalid()
 
         circle_3d = self._disambiguate_circle_3d_pair(observation.circle_3d_pair)

--- a/pye3d/two_sphere_model.py
+++ b/pye3d/two_sphere_model.py
@@ -33,7 +33,7 @@ logger = logging.getLogger(__name__)
 class TwoSphereModel(object):
     def __init__(
         self,
-        settings={"focal_length": 283.0, "resolution": (192, 192), "maxlen": 10000},
+        settings={"focal_length": 283.0, "resolution": (192, 192)},
     ):
         self.settings = settings
 
@@ -44,7 +44,7 @@ class TwoSphereModel(object):
             np.asarray([[*self.sphere_center]])
         )[0]
 
-        self.observation_storage = ObservationStorage(maxlen=self.settings["maxlen"])
+        self.observation_storage = ObservationStorage()
 
         self.debug_info = {
             "cost": -1.0,
@@ -137,6 +137,8 @@ class TwoSphereModel(object):
                 normalize(obs.circle_3d_pair[idx].normal)[0:2]
                 for obs, idx in zip(observations, prev_disambiguation)
             ]
+
+            debug_info["bins"] = [obs.bin for obs in observations]
 
             if debug_info["cost"] > 2:
                 filtered_residuals = median_filter(residuals, 50)

--- a/pye3d/two_sphere_model.py
+++ b/pye3d/two_sphere_model.py
@@ -198,7 +198,7 @@ class TwoSphereModel(object):
         self, observation: Observation, use_unprojection: bool = False
     ) -> Circle:
         if observation.invalid:
-            return Circle.create_invalid()
+            return Circle.null()
 
         circle_3d = self._disambiguate_circle_3d_pair(observation.circle_3d_pair)
         direction = normalize(circle_3d.center)

--- a/pye3d/two_sphere_model.py
+++ b/pye3d/two_sphere_model.py
@@ -24,7 +24,7 @@ from .geometry.projections import (
     unproject_ellipse,
 )
 from .geometry.utilities import normalize
-from .observation import Observation, ObservationStorage
+from .observation import Observation, ObservationStorage, BasicStorage
 from .refraction import Refractionizer
 
 logger = logging.getLogger(__name__)
@@ -33,11 +33,10 @@ logger = logging.getLogger(__name__)
 class TwoSphereModel(object):
     def __init__(
         self,
-        # TODO: Default storage for Kai
-        storage: ObservationStorage,
         camera: CameraModel,
+        storage: ObservationStorage = None,
     ):
-        self.storage = storage
+        self.storage = storage or BasicStorage()
         self.camera = camera
 
         self.refractionizer = Refractionizer()

--- a/pye3d/two_sphere_model.py
+++ b/pye3d/two_sphere_model.py
@@ -33,6 +33,7 @@ logger = logging.getLogger(__name__)
 class TwoSphereModel(object):
     def __init__(
         self,
+        # TODO: Default storage for Kai
         storage: ObservationStorage,
         camera: CameraModel,
     ):
@@ -119,6 +120,7 @@ class TwoSphereModel(object):
     def deep_sphere_estimate(
         _observations: Sequence[Observation],
     ) -> Tuple[np.ndarray, float, Dict[str, Any]]:
+        # TODO: delete
         # https://silo.tips/download/least-squares-intersection-of-lines
         # https://www.researchgate.net/publication/333490770_A_fast_approach_to_refraction-aware_eye-model_fitting_and_gaze_prediction
 

--- a/setup.py
+++ b/setup.py
@@ -24,12 +24,7 @@ cpp_dir = f"{package}/cpp"
 with open(here / "README.md") as f:
     long_description = f.read()
 
-requirements = [
-    "scipy>=1.2.1",
-    "numpy",
-    "joblib",
-    "scikit-learn",
-]
+requirements = ["scipy>=1.2.1", "numpy", "joblib", "scikit-learn", "sortedcontainers"]
 extras_require = {"dev": ["pytest", "tox"], "with-opencv": ["opencv-python"]}
 
 cmake_args = []


### PR DESCRIPTION
Rework pye3d internals to be more robust to slippage.

High-level changes:
- Use 3 different models on different time-scales:
  - Short-term for gaze direction
  - Long-term for eyeball center and stability bias for short-term
  - Ultra-long-term as stability bias for long-term
- Use observation storages that strategically forget observations based on time and spread across the image