### PR TITLE
3D search memory layout fix and confidence

### DIFF
--- a/pye3d/cpp/pupil_detection_3d.pyx
+++ b/pye3d/cpp/pupil_detection_3d.pyx
@@ -118,15 +118,17 @@ def search_on_sphere(edges,
     edges_on_sphere, idxs = unproject_edges_to_sphere(
         edges, focal_length, sphere_center, sphere_radius, resolution[0], resolution[1]
     )
+    if len(edges_on_sphere)<=0:
+         return np.asarray([0.,0.,-1.]), 0.0, [], []
 
     # convert edges numpy array to custom struct for passing to c++
     if edges_on_sphere.shape[0] == 0:
         return np.asarray([0, 0, -1]), 0, [], edges_on_sphere
     # first: make sure 2d data is c-contiguous, otherwise make c-contiguous copies
-    if not edges_on_sphere.flags["C_CONTIGUOUS"]:
-        edges_on_sphere = np.ascontiguousarray(edges_on_sphere)
+    if not edges_on_sphere.flags["F_CONTIGUOUS"]:  #EIGEN USES COLUMN-MAJOR MEMORY ALIGNMENT (AS FORTRAN DOES)
+        edges_on_sphere = np.asfortranarray(edges_on_sphere)
     # then create cython memory view, for raw pointer access
-    cdef double[:, ::1] edges_on_sphere_memview = edges_on_sphere
+    cdef double [:, :] edges_on_sphere_memview = edges_on_sphere
     # then copy data information
     # NOTE: This will provide direct access to the underlying data of the numpy array
     #  (given that it is c-contiguous and we did not copy). Therefore watch out to only

--- a/pye3d/cpp/search_on_sphere.h
+++ b/pye3d/cpp/search_on_sphere.h
@@ -13,11 +13,6 @@ See COPYING and COPYING.LESSER for license details.
 #include <math.h>
 #include <Eigen/Dense>
 #include <iostream>
-#include <opencv2/core.hpp>
-#include <opencv2/opencv.hpp>
-#include <opencv2/imgproc.hpp>
-#include <opencv2/videoio.hpp>
-#include <opencv2/core/eigen.hpp>
 
 struct numpy_matrix_view {
     double * data;
@@ -43,7 +38,7 @@ struct search_3d_result {
 
 };
 
-search_3d_result find_best_circle(const Eigen::MatrixXd & edges_on_sphere,
+search_3d_result find_best_circle(const Eigen::MatrixXd & edges_on_sphere_T,
                      const Eigen::Vector3d & initial_pupil_normal,
                      const double & initial_pupil_radius,
                      const Eigen::Vector3d & sphere_center,
@@ -53,6 +48,7 @@ search_3d_result find_best_circle(const Eigen::MatrixXd & edges_on_sphere,
                      const double & bandwidth_in_pixels,
                      const double & focal_length){
 
+    Eigen::MatrixXd edges_on_sphere = edges_on_sphere_T.transpose();
 
     const double h = sphere_radius - sqrt(pow(sphere_radius,2)-pow(initial_pupil_radius,2));
     const double pupil_chord = sqrt(2.0 * sphere_radius * h);

--- a/pye3d/detector_3d.py
+++ b/pye3d/detector_3d.py
@@ -316,7 +316,8 @@ class Detector3D(object):
         self.kalman_filter.correct(phi, theta, r)
 
     def _predict_from_3d_search(
-        self, frame: np.ndarray, best_guess: Circle, debug=True
+        # TODO: Remove debug code
+        self, frame: np.ndarray, best_guess: Circle, debug=False
     ) -> Search3DResult:
         no_result = Search3DResult(Circle.null(), 0.0)
 

--- a/pye3d/geometry/primitives.py
+++ b/pye3d/geometry/primitives.py
@@ -82,7 +82,7 @@ class Ellipse(Primitive):
     def circumference(self):
         a = self.minor_radius
         b = self.major_radius
-        return np.pi*(3.0*(a+b)-np.sqrt((3.*a+b)*(a+3.*b)))
+        return np.pi * (3.0 * (a + b) - np.sqrt((3.0 * a + b) * (a + 3.0 * b)))
 
     def area(self):
         return np.pi * self.minor_radius * self.major_radius

--- a/pye3d/geometry/primitives.py
+++ b/pye3d/geometry/primitives.py
@@ -79,6 +79,11 @@ class Ellipse(Primitive):
             self.major_radius = current_minor_radius
             self.angle = self.angle + np.pi / 2
 
+    def circumference(self):
+        a = self.minor_radius
+        b = self.major_radius
+        return np.pi*(3.0*(a+b)-np.sqrt((3.*a+b)*(a+3.*b)))
+
     def area(self):
         return np.pi * self.minor_radius * self.major_radius
 


### PR DESCRIPTION
- Fixed a memory alignment problem occurring when moving 2D edges from numpy to eigen
- Now calculating an updated confidence value from 3d search result and updating obervation.confidence with it
- Deleted opencv header files in search_on_sphere.h

There is still an issue to be resolved with respect how to deal with observation.confidence when 3d search is triggered by fails to come up with a better 2D pupil ellipse estimate.

This version has some debug code re search_3d, which probably can be deleted in the final version.