### PR TITLE
Expose 3d eye model RMS fitting residuals; disable them by default

### DIFF
--- a/pye3d/detector_3d.py
+++ b/pye3d/detector_3d.py
@@ -134,6 +134,12 @@ class Detector3D(object):
             "model_warmup_duration": model_warmup_duration,
         }
         self.reset()
+        logger.debug(
+            f"{type(self)} initialized with "
+            f"long_term_mode={long_term_mode} "
+            f"calculate_rms_residual={calculate_rms_residual} "
+            f"settings={self._settings}"
+        )
 
     @property
     def camera(self) -> CameraModel:

--- a/pye3d/eye_model/abstract.py
+++ b/pye3d/eye_model/abstract.py
@@ -21,6 +21,7 @@ from ..camera import CameraModel
 class SphereCenterEstimates(T.NamedTuple):
     projected: np.ndarray
     three_dim: np.ndarray
+    rms_residual: T.Optional[float] = None
 
 
 class TwoSphereModelAbstract(abc.ABC):
@@ -67,6 +68,7 @@ class TwoSphereModelAbstract(abc.ABC):
         from_2d: T.Optional[np.ndarray] = None,
         prior_3d: T.Optional[np.ndarray] = None,
         prior_strength: float = 0.0,
+        calculate_rms_residual: bool = False,
     ) -> SphereCenterEstimates:
         raise NotImplementedError
 
@@ -79,8 +81,9 @@ class TwoSphereModelAbstract(abc.ABC):
         self,
         sphere_center_2d: np.ndarray,
         prior_3d: T.Optional[np.ndarray] = None,
-        prior_strength=0.0,
-    ) -> np.ndarray:
+        prior_strength: float = 0.0,
+        calculate_rms_residual: bool = False,
+    ) -> T.Tuple[np.array, T.Optional[float]]:
         raise NotImplementedError
 
     # GAZE PREDICTION

--- a/pye3d/eye_model/asynchronous.py
+++ b/pye3d/eye_model/asynchronous.py
@@ -123,15 +123,23 @@ class TwoSphereModelAsync(TwoSphereModelAbstract):
         from_2d: T.Optional[np.ndarray] = None,
         prior_3d: T.Optional[np.ndarray] = None,
         prior_strength: float = 0.0,
+        calculate_rms_residual=False,
     ) -> SphereCenterEstimates:
         if not self._frontend._is_estimation_ongoing_flag.is_set():
             self.relay_command(
-                "estimate_sphere_center", from_2d, prior_3d, prior_strength
+                "estimate_sphere_center",
+                from_2d,
+                prior_3d,
+                prior_strength,
+                calculate_rms_residual,
             )
             self._frontend._is_estimation_ongoing_flag.set()
         projected_sphere_center = self._frontend.projected_sphere_center
         sphere_center = self._frontend.sphere_center
-        return SphereCenterEstimates(projected_sphere_center, sphere_center)
+        rms_residual = self._frontend.rms_residual
+        return SphereCenterEstimates(
+            projected_sphere_center, sphere_center, rms_residual
+        )
 
     def estimate_sphere_center_2d(self) -> np.ndarray:
         raise NotImplementedError
@@ -140,8 +148,9 @@ class TwoSphereModelAsync(TwoSphereModelAbstract):
         self,
         sphere_center_2d: np.ndarray,
         prior_3d: T.Optional[np.ndarray] = None,
-        prior_strength=0.0,
-    ) -> np.ndarray:
+        prior_strength: float = 0.0,
+        calculate_rms_residual: bool = False,
+    ) -> T.Tuple[np.array, T.Optional[float]]:
         raise NotImplementedError
 
     # GAZE PREDICTION

--- a/pye3d/eye_model/asynchronous.py
+++ b/pye3d/eye_model/asynchronous.py
@@ -85,6 +85,10 @@ class TwoSphereModelAsync(TwoSphereModelAbstract):
     def projected_sphere_center(self) -> np.ndarray:
         return self._frontend.projected_sphere_center
 
+    @property
+    def rms_residual(self) -> float:
+        return self._frontend.rms_residual
+
     def relay_command(self, function_name: str, *args, **kwargs):
         self._backend_process.send(function_name, *args, **kwargs)
 
@@ -93,8 +97,7 @@ class TwoSphereModelAsync(TwoSphereModelAbstract):
         backend: "_TwoSphereModelSyncedBackend", function_name: str, *args, **kwargs
     ):
         function = getattr(backend, function_name)
-        result = function(*args, **kwargs)
-        return result
+        return function(*args, **kwargs)
 
     @staticmethod
     def _setup_backend(*args, **kwargs) -> "_TwoSphereModelSyncedBackend":

--- a/pye3d/eye_model/base.py
+++ b/pye3d/eye_model/base.py
@@ -92,16 +92,27 @@ class TwoSphereModel(TwoSphereModelAbstract):
             np.asarray([[*self.sphere_center]])
         )[0]
 
-    def estimate_sphere_center(self, from_2d=None, prior_3d=None, prior_strength=0.0):
+    def estimate_sphere_center(
+        self,
+        from_2d=None,
+        prior_3d=None,
+        prior_strength=0.0,
+        calculate_rms_residual=False,
+    ):
         self.projected_sphere_center = (
             from_2d if from_2d is not None else self.estimate_sphere_center_2d()
         )
         sphere_center, rms_residual = self.estimate_sphere_center_3d(
-            self.projected_sphere_center, prior_3d, prior_strength
+            self.projected_sphere_center,
+            prior_3d,
+            prior_strength,
+            calculate_rms_residual=calculate_rms_residual,
         )
         self.set_sphere_center(sphere_center)
-        self.rms_residual = rms_residual
-        return SphereCenterEstimates(self.projected_sphere_center, sphere_center)
+        self.rms_residual = rms_residual if rms_residual is not None else float("nan")
+        return SphereCenterEstimates(
+            self.projected_sphere_center, sphere_center, rms_residual
+        )
 
     def estimate_sphere_center_2d(self):
         observations = self.storage.observations
@@ -118,8 +129,8 @@ class TwoSphereModel(TwoSphereModelAbstract):
         sphere_center_2d,
         prior_3d=None,
         prior_strength=0.0,
-        calculate_rms_residual=True,
-    ):
+        calculate_rms_residual=False,
+    ) -> T.Tuple[np.array, T.Optional[float]]:
         observations = self.storage.observations
         aux_3d = np.array([obs.aux_3d for obs in observations])
         gaze_2d = np.array(


### PR DESCRIPTION
Currently, the rms residual is always calculated but not used anywhere. To save performance, we disable this calculation by default. It can be enabled anywhere in the calculation chain:
- `Detector3D()`
- `TwoSphereModel.estimate_sphere_center()`
- `TwoSphereModel.estimate_sphere_center_3d()`

`TwoSphereModel.estimate_sphere_center()` returns a `SphereCenterEstimates` named tuple which was extended with a `rms_residual` field. This field is filled with a float if the function was called with `calculate_rms_residual=True`, else it is either filled with `None` or `NaN`.