### PR TITLE
simplification of Conic parameter calculation

### DIFF
--- a/pye3d/geometry/primitives.py
+++ b/pye3d/geometry/primitives.py
@@ -120,7 +120,12 @@ class Sphere(Primitive):
 
 
 class Conicoid(Primitive):
-    # Variable names refer to Safaee-Rad 1992
+    """
+    Coefficients of the general equation (implicit form) of a cone, given its vertex and base (ellipse/conic).
+    Formulae follow equations (1)-(3) of:
+    Safaee-Rad, R. et al.: "Three-Dimensional Location Estimation of Circular Features for Machine Vision",
+    IEEE Transactions on Robotics and Automation, Vol.8(5), 1992, pp624-640.
+    """
     __slots__ = tuple("ABCFGHUVWD")
 
     def __init__(self, conic, vertex):
@@ -147,7 +152,11 @@ class Conicoid(Primitive):
 
 
 class Conic(Primitive):
-    # Variable names refer to Safaee-Rad 1992
+    """
+    Coefficients A-F of the general equation (implicit form) of a conic
+    Ax² + Bxy + Cy² + Dx + Ey + F = 0
+    calculated from 5 ellipse parameters, see https://en.wikipedia.org/wiki/Ellipse#General_ellipse
+    """
     __slots__ = tuple("ABCDEF")
 
     def __init__(self, *args):
@@ -158,34 +167,14 @@ class Conic(Primitive):
             a2 = ellipse.major_radius ** 2
             b2 = ellipse.minor_radius ** 2
 
-            self.A = ax * ax / a2 + ay * ay / b2
-            self.B = 2.0 * ax * ay / a2 - 2.0 * ax * ay / b2
-            self.C = ay * ay / a2 + ax * ax / b2
-            self.D = (
-                -2 * ax * ay * ellipse.center[1] - 2 * ax * ax * ellipse.center[0]
-            ) / a2 + (
-                2 * ax * ay * ellipse.center[1] - 2 * ay * ay * ellipse.center[0]
-            ) / b2
-            self.E = (
-                -2 * ax * ay * ellipse.center[0] - 2 * ay * ay * ellipse.center[1]
-            ) / a2 + (
-                2 * ax * ay * ellipse.center[0] - 2 * ax * ax * ellipse.center[1]
-            ) / b2
-            self.F = (
-                (
-                    2 * ax * ay * ellipse.center[0] * ellipse.center[1]
-                    + ax * ax * ellipse.center[0] * ellipse.center[0]
-                    + ay * ay * ellipse.center[1] * ellipse.center[1]
-                )
-                / a2
-                + (
-                    -2 * ax * ay * ellipse.center[0] * ellipse.center[1]
-                    + ay * ay * ellipse.center[0] * ellipse.center[0]
-                    + ax * ax * ellipse.center[1] * ellipse.center[1]
-                )
-                / b2
-                - 1
-            )
+            self.A = a2 * ay * ay + b2 * ax * ax
+            self.B = 2. * (b2 - a2) * ax * ay
+            self.C = a2 * ax * ax + b2 * ay * ay
+            self.D = -2. * self.A * ellipse.center[0] - self.B * ellipse.center[1]
+            self.E = -self.B * ellipse.center[0] - 2. * self.C * ellipse.center[1]
+            self.F = self.A * ellipse.center[0] * ellipse.center[0] + self.B * ellipse.center[0] * ellipse.center[1] + self.C * \
+                ellipse.center[1] * ellipse.center[1] - a2 * b2
+
         if len(args) == 6:
             self.A, self.B, self.C, self.D, self.E, self.F = args
 

--- a/pye3d/geometry/primitives.py
+++ b/pye3d/geometry/primitives.py
@@ -126,6 +126,7 @@ class Conicoid(Primitive):
     Safaee-Rad, R. et al.: "Three-Dimensional Location Estimation of Circular Features for Machine Vision",
     IEEE Transactions on Robotics and Automation, Vol.8(5), 1992, pp624-640.
     """
+
     __slots__ = tuple("ABCFGHUVWD")
 
     def __init__(self, conic, vertex):
@@ -157,6 +158,7 @@ class Conic(Primitive):
     Ax² + Bxy + Cy² + Dx + Ey + F = 0
     calculated from 5 ellipse parameters, see https://en.wikipedia.org/wiki/Ellipse#General_ellipse
     """
+
     __slots__ = tuple("ABCDEF")
 
     def __init__(self, *args):
@@ -168,12 +170,16 @@ class Conic(Primitive):
             b2 = ellipse.minor_radius ** 2
 
             self.A = a2 * ay * ay + b2 * ax * ax
-            self.B = 2. * (b2 - a2) * ax * ay
+            self.B = 2.0 * (b2 - a2) * ax * ay
             self.C = a2 * ax * ax + b2 * ay * ay
-            self.D = -2. * self.A * ellipse.center[0] - self.B * ellipse.center[1]
-            self.E = -self.B * ellipse.center[0] - 2. * self.C * ellipse.center[1]
-            self.F = self.A * ellipse.center[0] * ellipse.center[0] + self.B * ellipse.center[0] * ellipse.center[1] + self.C * \
-                ellipse.center[1] * ellipse.center[1] - a2 * b2
+            self.D = -2.0 * self.A * ellipse.center[0] - self.B * ellipse.center[1]
+            self.E = -self.B * ellipse.center[0] - 2.0 * self.C * ellipse.center[1]
+            self.F = (
+                self.A * ellipse.center[0] * ellipse.center[0]
+                + self.B * ellipse.center[0] * ellipse.center[1]
+                + self.C * ellipse.center[1] * ellipse.center[1]
+                - a2 * b2
+            )
 
         if len(args) == 6:
             self.A, self.B, self.C, self.D, self.E, self.F = args


### PR DESCRIPTION
calculation of parameters A-F of the general implicit form of the conic can be simplified (see linked Wikipedia): new version are the old parameters multiplied by a²b² (which doesn't change the conic) and D,E,F can make use of previously calculated A,B,C.