### PR TITLE
Apply corneal-refraction correction to `diameter_3d` result

### DIFF
--- a/pye3d/detector_3d.py
+++ b/pye3d/detector_3d.py
@@ -543,8 +543,7 @@ class Detector3D(object):
 
         result["circle_3d"] = circle2dict(prediction_corrected.pupil_circle)
 
-        pupil_circle_long_term = self.long_term_model.predict_pupil_circle(observation)
-        result["diameter_3d"] = pupil_circle_long_term.radius * 2
+        result["diameter_3d"] = prediction_corrected.pupil_circle.radius * 2
 
         projected_pupil_circle = project_circle_into_image_plane(
             prediction_uncorrected.pupil_circle,


### PR DESCRIPTION
Previously, the corneal-refraction correction was only applied to the `circle_3d` field of the result. The `diameter_3d` value was not corrected for corneal-refraction effects. This was unintended and has been corrected in this PR.