### PR TITLE
Lower 3d search confidence results by 40%

### DIFF
--- a/pye3d/detector_3d.py
+++ b/pye3d/detector_3d.py
@@ -507,7 +507,7 @@ class Detector3D(object):
             else:
                 confidence_3d_search = 0.0
 
-        return Search3DResult(pupil_circle, confidence_3d_search)
+        return Search3DResult(pupil_circle, confidence_3d_search * 0.6)
 
     def _prepare_result(
         self,


### PR DESCRIPTION
Confidence for 3d search results was overestimated. This becomes apparent during blinks when 2d detection
is typically low and 3d search is applied. The resulting pupil detections are quite noisy compared to
their non-3d-search results counterparts with comparable confidence values.

This PR attempts to solve this by reducing the 3d search result confidence by 40%.