### PR TITLE
Fix gaze 3d pair direction

### DIFF
--- a/pye3d/observation.py
+++ b/pye3d/observation.py
@@ -48,11 +48,7 @@ class Observation:
         self.circle_3d_pair = circle_3d_pair
 
         self.gaze_3d_pair = [
-            Line(
-                circle_3d_pair[i].center,
-                circle_3d_pair[i].center + circle_3d_pair[i].normal,
-            )
-            for i in [0, 1]
+            Line(circle_3d_pair[i].center, circle_3d_pair[i].normal) for i in [0, 1]
         ]
         self.gaze_2d = project_line_into_image_plane(self.gaze_3d_pair[0], focal_length)
         self.gaze_2d_line = np.array([*self.gaze_2d.origin, *self.gaze_2d.direction])

--- a/pye3d/observation.py
+++ b/pye3d/observation.py
@@ -50,7 +50,7 @@ class Observation:
         self.gaze_3d_pair = [
             Line(
                 circle_3d_pair[i].center,
-                circle_3d_pair[i].normal,
+                circle_3d_pair[i].center + circle_3d_pair[i].normal,
             )
             for i in [0, 1]
         ]


### PR DESCRIPTION
- Revert accidentally commited change in https://github.com/pupil-labs/pye3d-detector/commit/08b7060f3743f5f6a25302117dc67318766a2960
- [Correctly calculate direction of Observation's gaze_3d_pair lines](https://github.com/pupil-labs/pye3d-detector/commit/e351678edec51a337325b2ad9291f5b26d6e4fa1)

In practice, this fix does not affect the fitted 3d model as the 3d lines (old and new) project to nearly the same 2d line.